### PR TITLE
Link flathub package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # nottetris2
 Runs on LÖVE 0.7.2
+
+Website: https://stabyourself.net/nottetris2/
+
+# Installation
+
+On Linux:
+
+<a href='https://flathub.org/apps/details/net.stabyourself.nottetris2'><img width='240' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>


### PR DESCRIPTION
Finally https://github.com/flathub/flathub/pull/377 was fixed. Advertise one-click installation available for all modern Linux distros (and you don't even have to care about those old LÖVE requirements) 🐧 ❤️